### PR TITLE
Add support for controlling zone based firewall policies

### DIFF
--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -46,6 +46,7 @@ class UnifiEntityLoader:
             hub.api.port_forwarding.update,
             hub.api.sites.update,
             hub.api.system_information.update,
+            hub.api.firewall_policies.update,
             hub.api.traffic_rules.update,
             hub.api.traffic_routes.update,
             hub.api.wlans.update,

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -7,7 +7,9 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["aiounifi"],
-  "requirements": ["aiounifi==81"],
+  "requirements": [
+    "git+https://github.com/Samywamy10/aiounifi@zone-based-rules"
+  ],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -7,9 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["aiounifi"],
-  "requirements": [
-    "git+https://github.com/Samywamy10/aiounifi@zone-based-rules"
-  ],
+  "requirements": ["aiounifi==82"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -4,6 +4,7 @@ Support for controlling power supply of clients which are powered over Ethernet 
 Support for controlling network access of clients selected in option flow.
 Support for controlling deep packet inspection (DPI) restriction groups.
 Support for controlling WLAN availability.
+Support for controlling zone based traffic rules.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ import aiounifi
 from aiounifi.interfaces.api_handlers import ItemEvent
 from aiounifi.interfaces.clients import Clients
 from aiounifi.interfaces.dpi_restriction_groups import DPIRestrictionGroups
+from aiounifi.interfaces.firewall_policies import FirewallPolicies
 from aiounifi.interfaces.outlets import Outlets
 from aiounifi.interfaces.port_forwarding import PortForwarding
 from aiounifi.interfaces.ports import Ports
@@ -29,6 +31,7 @@ from aiounifi.models.device import DeviceSetOutletRelayRequest
 from aiounifi.models.dpi_restriction_app import DPIRestrictionAppEnableRequest
 from aiounifi.models.dpi_restriction_group import DPIRestrictionGroup
 from aiounifi.models.event import Event, EventKey
+from aiounifi.models.firewall_policy import FirewallPolicy, FirewallPolicyUpdateRequest
 from aiounifi.models.outlet import Outlet
 from aiounifi.models.port import Port
 from aiounifi.models.port_forward import PortForward, PortForwardEnableRequest
@@ -172,6 +175,17 @@ async def async_traffic_rule_control_fn(
     await hub.api.traffic_rules.update()
 
 
+async def async_firewall_policy_control_fn(
+    hub: UnifiHub, obj_id: str, target: bool
+) -> None:
+    """Control firewall policy state."""
+    policy = hub.api.firewall_policies[obj_id].raw
+    policy["enabled"] = target
+    await hub.api.request(FirewallPolicyUpdateRequest.create(policy))
+    # Update the policies so the UI is updated appropriately
+    await hub.api.firewall_policies.update()
+
+
 async def async_traffic_route_control_fn(
     hub: UnifiHub, obj_id: str, target: bool
 ) -> None:
@@ -274,6 +288,22 @@ ENTITY_DESCRIPTIONS: tuple[UnifiSwitchEntityDescription, ...] = (
         name_fn=lambda traffic_rule: traffic_rule.description,
         object_fn=lambda api, obj_id: api.traffic_rules[obj_id],
         unique_id_fn=lambda hub, obj_id: f"traffic_rule-{obj_id}",
+    ),
+    UnifiSwitchEntityDescription[FirewallPolicies, FirewallPolicy](
+        key="Firewall policy control",
+        translation_key="firewall_policy_control",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        api_handler_fn=lambda api: api.firewall_policies,
+        control_fn=async_firewall_policy_control_fn,
+        device_info_fn=async_unifi_network_device_info_fn,
+        is_on_fn=lambda hub, firewall_policy: firewall_policy.enabled,
+        name_fn=lambda firewall_policy: firewall_policy.name,
+        object_fn=lambda api, obj_id: api.firewall_policies[obj_id],
+        unique_id_fn=lambda hub, obj_id: f"firewall_policy-{obj_id}",
+        supported_fn=lambda hub, obj_id: not hub.api.firewall_policies[
+            obj_id
+        ].predefined,
     ),
     UnifiSwitchEntityDescription[TrafficRoutes, TrafficRoute](
         key="Traffic route control",

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -132,6 +132,24 @@ async def async_dpi_group_control_fn(hub: UnifiHub, obj_id: str, target: bool) -
     )
 
 
+async def async_firewall_policy_control_fn(
+    hub: UnifiHub, obj_id: str, target: bool
+) -> None:
+    """Control firewall policy state."""
+    policy = hub.api.firewall_policies[obj_id].raw
+    policy["enabled"] = target
+    await hub.api.request(FirewallPolicyUpdateRequest.create(policy))
+    # Update the policies so the UI is updated appropriately
+    await hub.api.firewall_policies.update()
+
+
+@callback
+def async_firewall_policy_supported_fn(hub: UnifiHub, obj_id: str) -> bool:
+    """Check if firewall policy is able to be controlled. Predefined policies are unable to be turned off."""
+    policy = hub.api.firewall_policies[obj_id]
+    return not policy.predefined
+
+
 @callback
 def async_outlet_switching_supported_fn(hub: UnifiHub, obj_id: str) -> bool:
     """Determine if an outlet supports switching."""
@@ -173,17 +191,6 @@ async def async_traffic_rule_control_fn(
     await hub.api.request(TrafficRuleEnableRequest.create(traffic_rule, target))
     # Update the traffic rules so the UI is updated appropriately
     await hub.api.traffic_rules.update()
-
-
-async def async_firewall_policy_control_fn(
-    hub: UnifiHub, obj_id: str, target: bool
-) -> None:
-    """Control firewall policy state."""
-    policy = hub.api.firewall_policies[obj_id].raw
-    policy["enabled"] = target
-    await hub.api.request(FirewallPolicyUpdateRequest.create(policy))
-    # Update the policies so the UI is updated appropriately
-    await hub.api.firewall_policies.update()
 
 
 async def async_traffic_route_control_fn(
@@ -250,6 +257,20 @@ ENTITY_DESCRIPTIONS: tuple[UnifiSwitchEntityDescription, ...] = (
         supported_fn=lambda hub, obj_id: bool(hub.api.dpi_groups[obj_id].dpiapp_ids),
         unique_id_fn=lambda hub, obj_id: obj_id,
     ),
+    UnifiSwitchEntityDescription[FirewallPolicies, FirewallPolicy](
+        key="Firewall policy control",
+        translation_key="firewall_policy_control",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        api_handler_fn=lambda api: api.firewall_policies,
+        control_fn=async_firewall_policy_control_fn,
+        device_info_fn=async_unifi_network_device_info_fn,
+        is_on_fn=lambda hub, firewall_policy: firewall_policy.enabled,
+        name_fn=lambda firewall_policy: firewall_policy.name,
+        object_fn=lambda api, obj_id: api.firewall_policies[obj_id],
+        unique_id_fn=lambda hub, obj_id: f"firewall_policy-{obj_id}",
+        supported_fn=async_firewall_policy_supported_fn,
+    ),
     UnifiSwitchEntityDescription[Outlets, Outlet](
         key="Outlet control",
         device_class=SwitchDeviceClass.OUTLET,
@@ -288,22 +309,6 @@ ENTITY_DESCRIPTIONS: tuple[UnifiSwitchEntityDescription, ...] = (
         name_fn=lambda traffic_rule: traffic_rule.description,
         object_fn=lambda api, obj_id: api.traffic_rules[obj_id],
         unique_id_fn=lambda hub, obj_id: f"traffic_rule-{obj_id}",
-    ),
-    UnifiSwitchEntityDescription[FirewallPolicies, FirewallPolicy](
-        key="Firewall policy control",
-        translation_key="firewall_policy_control",
-        device_class=SwitchDeviceClass.SWITCH,
-        entity_category=EntityCategory.CONFIG,
-        api_handler_fn=lambda api: api.firewall_policies,
-        control_fn=async_firewall_policy_control_fn,
-        device_info_fn=async_unifi_network_device_info_fn,
-        is_on_fn=lambda hub, firewall_policy: firewall_policy.enabled,
-        name_fn=lambda firewall_policy: firewall_policy.name,
-        object_fn=lambda api, obj_id: api.firewall_policies[obj_id],
-        unique_id_fn=lambda hub, obj_id: f"firewall_policy-{obj_id}",
-        supported_fn=lambda hub, obj_id: not hub.api.firewall_policies[
-            obj_id
-        ].predefined,
     ),
     UnifiSwitchEntityDescription[TrafficRoutes, TrafficRoute](
         key="Traffic route control",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -404,7 +404,7 @@ aiotedee==0.2.20
 aiotractive==0.6.0
 
 # homeassistant.components.unifi
-aiounifi==81
+aiounifi==82
 
 # homeassistant.components.usb
 aiousbwatcher==1.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -386,7 +386,7 @@ aiotedee==0.2.20
 aiotractive==0.6.0
 
 # homeassistant.components.unifi
-aiounifi==81
+aiounifi==82
 
 # homeassistant.components.usb
 aiousbwatcher==1.1.1

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -178,6 +178,7 @@ def fixture_request(
     site_payload: list[dict[str, Any]],
     system_information_payload: list[dict[str, Any]],
     wlan_payload: list[dict[str, Any]],
+    firewall_policy_payload: list[dict[str, Any]],
 ) -> Callable[[str], None]:
     """Mock default UniFi requests responses."""
 
@@ -216,6 +217,9 @@ def fixture_request(
         mock_get_request(f"/api/s/{site_id}/rest/wlanconf", wlan_payload)
         mock_get_request(f"/v2/api/site/{site_id}/trafficrules", traffic_rule_payload)
         mock_get_request(f"/v2/api/site/{site_id}/trafficroutes", traffic_route_payload)
+        mock_get_request(
+            f"/v2/api/site/{site_id}/firewall-policies", firewall_policy_payload
+        )
 
     return __mock_requests
 
@@ -302,6 +306,12 @@ def traffic_route_payload_data() -> list[dict[str, Any]]:
 @pytest.fixture(name="wlan_payload")
 def fixture_wlan_data() -> list[dict[str, Any]]:
     """WLAN data."""
+    return []
+
+
+@pytest.fixture(name="firewall_policy_payload")
+def firewall_policy_payload_data() -> list[dict[str, Any]]:
+    """Firewall policy data."""
     return []
 
 

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -172,13 +172,13 @@ def fixture_request(
     device_payload: list[dict[str, Any]],
     dpi_app_payload: list[dict[str, Any]],
     dpi_group_payload: list[dict[str, Any]],
+    firewall_policy_payload: list[dict[str, Any]],
     port_forward_payload: list[dict[str, Any]],
     traffic_rule_payload: list[dict[str, Any]],
     traffic_route_payload: list[dict[str, Any]],
     site_payload: list[dict[str, Any]],
     system_information_payload: list[dict[str, Any]],
     wlan_payload: list[dict[str, Any]],
-    firewall_policy_payload: list[dict[str, Any]],
 ) -> Callable[[str], None]:
     """Mock default UniFi requests responses."""
 
@@ -212,14 +212,14 @@ def fixture_request(
         mock_get_request(f"/api/s/{site_id}/stat/device", device_payload)
         mock_get_request(f"/api/s/{site_id}/rest/dpiapp", dpi_app_payload)
         mock_get_request(f"/api/s/{site_id}/rest/dpigroup", dpi_group_payload)
+        mock_get_request(
+            f"/v2/api/site/{site_id}/firewall-policies", firewall_policy_payload
+        )
         mock_get_request(f"/api/s/{site_id}/rest/portforward", port_forward_payload)
         mock_get_request(f"/api/s/{site_id}/stat/sysinfo", system_information_payload)
         mock_get_request(f"/api/s/{site_id}/rest/wlanconf", wlan_payload)
         mock_get_request(f"/v2/api/site/{site_id}/trafficrules", traffic_rule_payload)
         mock_get_request(f"/v2/api/site/{site_id}/trafficroutes", traffic_route_payload)
-        mock_get_request(
-            f"/v2/api/site/{site_id}/firewall-policies", firewall_policy_payload
-        )
 
     return __mock_requests
 
@@ -254,6 +254,12 @@ def fixture_dpi_app_data() -> list[dict[str, Any]]:
 @pytest.fixture(name="dpi_group_payload")
 def fixture_dpi_group_data() -> list[dict[str, Any]]:
     """DPI group data."""
+    return []
+
+
+@pytest.fixture(name="firewall_policy_payload")
+def firewall_policy_payload_data() -> list[dict[str, Any]]:
+    """Firewall policy data."""
     return []
 
 
@@ -306,12 +312,6 @@ def traffic_route_payload_data() -> list[dict[str, Any]]:
 @pytest.fixture(name="wlan_payload")
 def fixture_wlan_data() -> list[dict[str, Any]]:
     """WLAN data."""
-    return []
-
-
-@pytest.fixture(name="firewall_policy_payload")
-def firewall_policy_payload_data() -> list[dict[str, Any]]:
-    """Firewall policy data."""
     return []
 
 


### PR DESCRIPTION
Using my changes here: https://github.com/Kane610/aiounifi/pull/813 to aiounifi, expose switches for each of the non-predefined zone based firewall rules.

![CleanShot 2025-02-16 at 21 50 09@2x](https://github.com/user-attachments/assets/b9b16ef2-2387-45fd-b31d-b4b0a498769e)

![CleanShot 2025-02-16 at 21 50 22@2x](https://github.com/user-attachments/assets/37776ead-d8e4-46c9-beff-f3e74b4ab804)

Video showing updates reflecting in Unifi console:

https://github.com/user-attachments/assets/f973085a-d518-444f-983d-0e03fc74eae5

